### PR TITLE
Enable eapi for transport

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -34,12 +34,4 @@
   eos_command:
     commands: 'write memory'
     provider: "{{ provider|default(omit) }}"
-    auth_pass: "{{ auth_pass|default(omit) }}"
-    authorize: "{{ authorize|default(omit) }}"
-    host: "{{ host|default(omit) }}"
-    password: "{{ password|default(omit) }}"
-    port: "{{ port|default(omit) }}"
-    transport: 'cli'
-    use_ssl: "{{ use_ssl|default(omit) }}"
-    username: "{{ username|default(omit) }}"
   when: eos_save_running_config

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,9 @@
 
 - name: Gather EOS configuration
   eos_command:
-    commands: 'show running-config all | exclude \.\*'
+    commands:
+      - command: 'show running-config all | exclude \.\*'
+        output: text
     provider: "{{ provider | default(omit) }}"
   register: output
   no_log: "{{ no_log | default(true) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,14 +17,6 @@
   eos_command:
     commands: 'show running-config all | exclude \.\*'
     provider: "{{ provider | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
-    transport: "cli"
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
   register: output
   no_log: "{{ no_log | default(true) }}"
   when: _eos_config is not defined

--- a/tasks/resources2.1.yml
+++ b/tasks/resources2.1.yml
@@ -5,15 +5,7 @@
     src: interface.j2
     include_defaults: true
     config: "{{ _eos_config | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
     provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
   notify: save running config
   when: item.name is defined
   with_items: "{{ interfaces | default([]) }}"

--- a/tasks/resources2.2.yml
+++ b/tasks/resources2.2.yml
@@ -5,15 +5,7 @@
     src: interface.j2
     defaults: true
     config: "{{ _eos_config | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
     provider: "{{ provider | default(omit) }}"
-    transport: 'cli'
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
   notify: save running config
   when: item.name is defined
   with_items: "{{ interfaces | default([]) }}"


### PR DESCRIPTION
This changes all the actions to use only the ```provider``` dictionary settings for connection, thus removing hardcoded entries of cli transport only

This fixes #11 

All stand alone connection/transport settings are removed and must come in via the ```provider``` dictionary only