### PR TITLE
Add interface attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,24 @@ The tasks in this role are driven by the ``interfaces`` object described below:
 
 **interfaces** (list) each entry contains the following keys:
 
-|         Key | Type                      | Notes                                                                                                                                                                                                |
-|------------:|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|        name | string (required)         | The unique interface identifier name. The interface name must use the full interface name (no abbreviated names). For example, interfaces should be specified as Ethernet1 not Et1                   |
-| description | string                    | Configures a one lne ASCII description for the interface.                                                                                                                                            |
-|      enable | boolean: true*, false     | Configures the administrative state for the interface. Setting the value to true will adminstrative enable the interface and setting the value to false will administratively disable the interface. |
-|       state | choices: present*, absent | Set the state for the interface configuration.                                                                                                                                                       |
+|           Key | Type                          | Notes                                                                                                                                                                                                |
+|--------------:|-------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|          name | string (required)             | The unique interface identifier name. The interface name must use the full interface name (no abbreviated names). For example, interfaces should be specified as Ethernet1 not Et1                   |
+|   description | string                        | Configures a one lne ASCII description for the interface.                                                                                                                                            |
+|        enable | boolean: true*, false         | Configures the administrative state for the interface. Setting the value to true will adminstrative enable the interface and setting the value to false will administratively disable the interface. |
+|         state | choices: present*, absent     | Set the state for the interface configuration.                                                                                                                                                       |
+| channel_group | dictionary                    | Configure the interface in a Port Channel. If not present, or number sub key is missing, the Port Channel with be defaulted to be removed                                                            |
+|         .mode | choices: on, active*, passive | Set the mode of the the Port Channel group.                                                                                                                                                          |
+|       .number | integer                       | Set the number the Port Channel group.                                                                                                                                                               |
+|          lacp | dictionary                    | Configure lacp paramaters for Ethernet interface, if not present both settings will be defaulted                                                                                                     |
+|     .priority | integer                       | Set the lacp port-priority. Default if not present                                                                                                                                                   |
+|         .rate | choices: normal*, fast        | Set the lacp rate. Defaulted if not present                                                                                                                                                          |
+|          vlan | dictionary                    | Configure switchport vlan settings for interface based on subkey, if not present all sub settings will be defaulted                                                                                  |
+|         .mode | choices: access*, trunk, etc  | Connfigure switchport mode for the interface. If not present will be defaulted (same as access)                                                                                                      |
+|       .access | integer                       | Set switchport access vlan to given number, when in switchport mode access                                                                                                                           |
+|       .native | integer                       | Set switchport native trunk vlan, when in switchport mode trunk.                                                                                                                                     |
+|      .allowed | string                        | Set the vlans allowed on in the inerface when using trunk mode                                                                                                                                       |
+|        .group | string                        | Set the trunk group allowed on the interface                                                                                                                                                         |
 
 
 ```

--- a/templates/interface.j2
+++ b/templates/interface.j2
@@ -128,12 +128,22 @@ interface {{ intf }}
    default switchport mode
 
       {% endif %}
+      {% if vlan.allowed is defined and vlan.allowed %}
+
+   switchport trunk allowed vlan {{ vlan.allowed|string }}
+
+      {% else %}
+
+   default switchport trunk allowed vlan
+
+      {% endif %}
 
    {% else %}
 
    default switchport access vlan
    default switchport mode
    default switchport trunk native vlan
+   default switchport trunk allowed vlan
 
    {% endif %}
 

--- a/templates/interface.j2
+++ b/templates/interface.j2
@@ -137,6 +137,15 @@ interface {{ intf }}
    default switchport trunk allowed vlan
 
       {% endif %}
+      {% if vlan.group is defined and vlan.group %}
+
+   switchport trunk group {{ vlan.group }}
+
+      {% else %}
+
+   default switchport trunk group
+
+      {% endif %}
 
    {% else %}
 
@@ -144,6 +153,7 @@ interface {{ intf }}
    default switchport mode
    default switchport trunk native vlan
    default switchport trunk allowed vlan
+   default switchport trunk group
 
    {% endif %}
 

--- a/templates/interface.j2
+++ b/templates/interface.j2
@@ -119,11 +119,21 @@ interface {{ intf }}
    default switchport mode
 
       {% endif %}
+      {% if vlan.native is defined and vlan.native %}
+
+   switchport trunk native vlan {{ vlan.native }}
+
+      {% else %}
+
+   default switchport mode
+
+      {% endif %}
 
    {% else %}
 
    default switchport access vlan
    default switchport mode
+   default switchport trunk native vlan
 
    {% endif %}
 

--- a/templates/interface.j2
+++ b/templates/interface.j2
@@ -23,22 +23,21 @@ no interface {{ intf }}
 
 {% elif state == 'present' %}
    {# Set up interface #}
-   {% set intf_block = _eos_config | config_block('interface ' ~ item.name, indent=3) %}
-   {% if intf_block %}
-      {# Interface exists - make sure parameters match #}
 
 interface {{ intf }}
 
-      {# Set the description if necessary #}
-      {% if item.description is defined %}
-         {% set desc = item.description %}
-         {% if desc %}
+   {% set intf_block = _eos_config | config_block('interface ' ~ item.name, indent=3) %}
+
+   {% if item.description is defined %}
+      {% set desc = item.description %}
+      {% if desc is defined and desc %}
 
    description {{ desc }}
 
-         {% elif desc == '' %}
-            {# description contains empty string #}
-            {# default current description if one exists #}
+      {% elif desc == '' %}
+         {# description contains empty string #}
+         {# default current description if one exists #}
+         {% if intf_block %}
             {% set intf_desc = intf_block | join('\n') | re_search('^no description') %}
             {% if not intf_desc %}
 
@@ -47,35 +46,16 @@ interface {{ intf }}
             {% endif %}
          {% endif %}
       {% endif %}
-
-      {# Enable/disable interface if necessary #}
-      {% set enable = item.enable | default(default_enable) %}
-      {% if enable %}
-
-   no shutdown
-
-      {% elif enable is defined and not enable %}
-
-   shutdown
-
-      {% endif %}
-
    {% else %}
-      {# Interface does not yet exist #}
+      {# no description defined at all #}
 
-interface {{ intf }}
-
-      {% if item.description is defined %}
-         {% set desc = item.description %}
-         {% if desc is defined and desc %}
-
-   description {{ desc }}
-
-         {% endif %}
-      {% endif %}
-      {% set enbl = (item.enable|default(default_enable) == True) | ternary('no shutdown','shutdown') %}
-
-   {{ enbl }}
+   default description
 
    {% endif %}
+
+
+   {# Enable/disable interface if necessary #}
+   {% set enbl = (item.enable|default(default_enable) == True) | ternary('no shutdown','shutdown') %}
+
+   {{ enbl }}
 {% endif %}

--- a/templates/interface.j2
+++ b/templates/interface.j2
@@ -53,6 +53,7 @@ interface {{ intf }}
 
    {% endif %}
 
+   {# channel group #}
    {% if item.channel_group is defined %}
       {% set cg = item.channel_group %}
 
@@ -61,7 +62,38 @@ interface {{ intf }}
    {% else %}
       {% if 'Ethernet' in intf %}
 
-   default channel-group
+   no channel-group
+
+      {% endif %}
+   {% endif %}
+
+   {# lacp #}
+   {% if item.lacp is defined %}
+      {% set lacp = item.lacp %}
+      {% if lacp.priority is defined and lacp.priority %}
+
+   lacp port-priority {{ lacp.priority }}
+
+      {% else %}
+
+   default lacp port-priority
+
+      {% endif %}
+      {% if lacp.rate is defined and lacp.rate %}
+
+   lacp rate {{ lacp.rate }}
+
+      {% else %}
+
+   default lacp rate
+
+      {% endif %}
+
+   {% else %}
+      {% if 'Ethernet' in intf %}
+
+   default lacp port-priority
+   default lacp rate
 
       {% endif %}
    {% endif %}

--- a/templates/interface.j2
+++ b/templates/interface.j2
@@ -68,7 +68,8 @@ interface {{ intf }}
    {% endif %}
 
    {# lacp #}
-   {% if item.lacp is defined %}
+   {% if 'Ethernet' in intf %}
+   {% if item.lacp is defined and 'Ethernet' in intf %}
       {% set lacp = item.lacp %}
       {% if lacp.priority is defined and lacp.priority %}
 
@@ -90,12 +91,11 @@ interface {{ intf }}
       {% endif %}
 
    {% else %}
-      {% if 'Ethernet' in intf %}
 
    default lacp port-priority
    default lacp rate
 
-      {% endif %}
+   {% endif %}
    {% endif %}
 
    {# vlan #}

--- a/templates/interface.j2
+++ b/templates/interface.j2
@@ -110,10 +110,20 @@ interface {{ intf }}
    default switchport access vlan
 
       {% endif %}
+      {% if vlan.mode is defined and vlan.mode %}
+
+   switchport mode {{ vlan.mode }}
+
+      {% else %}
+
+   default switchport mode
+
+      {% endif %}
 
    {% else %}
 
    default switchport access vlan
+   default switchport mode
 
    {% endif %}
 

--- a/templates/interface.j2
+++ b/templates/interface.j2
@@ -53,6 +53,18 @@ interface {{ intf }}
 
    {% endif %}
 
+   {% if item.channel_group is defined %}
+      {% set cg = item.channel_group %}
+
+   channel-group {{ cg.number }} mode {{ cg.mode|default("active")}}
+
+   {% else %}
+      {% if 'Ethernet' in intf %}
+
+   default channel-group
+
+      {% endif %}
+   {% endif %}
 
    {# Enable/disable interface if necessary #}
    {% set enbl = (item.enable|default(default_enable) == True) | ternary('no shutdown','shutdown') %}

--- a/templates/interface.j2
+++ b/templates/interface.j2
@@ -98,6 +98,25 @@ interface {{ intf }}
       {% endif %}
    {% endif %}
 
+   {# vlan #}
+   {% if item.vlan is defined %}
+      {% set vlan = item.vlan %}
+      {% if vlan.access is defined and vlan.access %}
+
+   switchport access vlan {{ vlan.access }}
+
+      {% else %}
+
+   default switchport access vlan
+
+      {% endif %}
+
+   {% else %}
+
+   default switchport access vlan
+
+   {% endif %}
+
    {# Enable/disable interface if necessary #}
    {% set enbl = (item.enable|default(default_enable) == True) | ternary('no shutdown','shutdown') %}
 


### PR DESCRIPTION
This addresses #13 for my personal needs to manage lacp options and port channel membership

I have not added to the builtin tests for these, but it passes the works for me

This PR also includes options to manage switchport settings & vlan membership. These settings are typically managed from the ```ansible-eos-bridging``` role. However, I'm not a real network person I only play one at work & being more of a programmer background it makes more sense to me to have all the settings for my ports only listed in one place in my host vars. Thus I've moved these switchport settings into here

These changes allow me to manage almost all of the bits of my config via ansible

It might be of interest to others, thus the PR. Take them or leave them